### PR TITLE
06/02 Arata's update ver2

### DIFF
--- a/java/tf2/entity/projectile/enemy/EntityEnemyBullet.java
+++ b/java/tf2/entity/projectile/enemy/EntityEnemyBullet.java
@@ -1,13 +1,10 @@
 package tf2.entity.projectile.enemy;
 
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.util.EnumParticleTypes;
-import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
-import tf2.entity.mob.enemy.EntityMobTF;
 import tf2.entity.projectile.IEnemyProjectile;
 import tf2.entity.projectile.player.EntityBullet;
 
@@ -46,27 +43,6 @@ public class EntityEnemyBullet extends EntityBullet implements IEnemyProjectile
 				float var16 = 0.2F * (float) var1;
 				this.world.spawnParticle(EnumParticleTypes.SMOKE_NORMAL, this.posX + x * (double) var16, this.posY + 0.1D + y * (double) var16, this.posZ + z * (double) var16, 0.0D, 0.0D, 0.0D, new int[0]);
 			}
-		}
-	}
-
-	@Override
-	protected void onHit(RayTraceResult raytraceResultIn)
-	{
-		Entity entity = raytraceResultIn.entityHit;
-		if (entity != null)
-		{
-			if (!(entity instanceof EntityMobTF))
-			{
-				super.onHit(raytraceResultIn);
-			}
-			else
-			{
-				this.setEntityDead();
-			}
-		}
-		else
-		{
-			super.onHitBlock(raytraceResultIn);
 		}
 	}
 }

--- a/java/tf2/entity/projectile/enemy/EntityEnemyBulletHE.java
+++ b/java/tf2/entity/projectile/enemy/EntityEnemyBulletHE.java
@@ -92,6 +92,7 @@ public class EntityEnemyBulletHE extends EntityTFProjectile implements IEnemyPro
 			DamageSource var201 = this.damageSource();
 			var8.attackEntityFrom(var201, (float) this.damage * 0.5F);
 			var8.hurtResistantTime = 0;
+
 		}
 	}
 

--- a/java/tf2/entity/projectile/enemy/EntityEnemyImpact.java
+++ b/java/tf2/entity/projectile/enemy/EntityEnemyImpact.java
@@ -1,17 +1,7 @@
 package tf2.entity.projectile.enemy;
 
-import net.minecraft.enchantment.EnchantmentHelper;
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.entity.player.EntityPlayerMP;
-import net.minecraft.network.play.server.SPacketChangeGameState;
-import net.minecraft.util.DamageSource;
-import net.minecraft.util.math.MathHelper;
-import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
-import tf2.TFDamageSource;
-import tf2.entity.mob.enemy.EntityMobTF;
 import tf2.entity.projectile.IEnemyProjectile;
 import tf2.entity.projectile.player.EntityImpact;
 
@@ -34,65 +24,5 @@ public class EntityEnemyImpact extends EntityImpact implements IEnemyProjectile
 	{
 		super(worldIn, throwerIn);
 		this.setTickAir(50);
-	}
-
-	@Override
-	public void onHit(RayTraceResult raytraceResultIn)
-	{
-	    Entity entity = raytraceResultIn.entityHit;
-
-	    if (entity != null)
-	    {
-	    	if (!(entity instanceof EntityMobTF))
-	    	{
-	    		DamageSource damagesource;
-
-	            if (this.thrower == null)
-	            {
-	                damagesource = TFDamageSource.causeBulletDamage(this, this);
-	            }
-	            else
-	            {
-	                damagesource = TFDamageSource.causeBulletDamage(this, this.thrower);
-	            }
-
-	            if (this.isBurning())
-	            {
-	                entity.setFire(5);
-	            }
-
-	            if (entity.attackEntityFrom(damagesource, (float)this.damage))
-	            {
-	                if (entity instanceof EntityLivingBase)
-	                {
-	                    EntityLivingBase entitylivingbase = (EntityLivingBase)entity;
-
-	                    if (this.knockbackStrength > 0)
-	                    {
-	                        float f1 = MathHelper.sqrt(this.motionX * this.motionX + this.motionZ * this.motionZ);
-
-	                        if (f1 > 0.0F)
-	                        {
-	                            entitylivingbase.addVelocity(this.motionX * (double)this.knockbackStrength * 0.6000000238418579D / (double)f1, 0.1D, this.motionZ * (double)this.knockbackStrength * 0.6000000238418579D / (double)f1);
-	                        }
-	                    }
-
-	                    if (this.thrower instanceof EntityLivingBase)
-	                    {
-	                        EnchantmentHelper.applyThornEnchantments(entitylivingbase, this.thrower);
-	                        EnchantmentHelper.applyArthropodEnchantments((EntityLivingBase)this.thrower, entitylivingbase);
-	                    }
-
-	                    this.bulletHit(entitylivingbase);
-	                    entitylivingbase.hurtResistantTime = 0;
-
-	                    if (this.thrower != null && entitylivingbase != this.thrower && entitylivingbase instanceof EntityPlayer && this.thrower instanceof EntityPlayerMP)
-	                    {
-	                        ((EntityPlayerMP)this.thrower).connection.sendPacket(new SPacketChangeGameState(6, 0.0F));
-	                    }
-	                }
-	            }
-	    	}
-	    }
 	}
 }

--- a/java/tf2/entity/projectile/enemy/EntityEnemyMortar.java
+++ b/java/tf2/entity/projectile/enemy/EntityEnemyMortar.java
@@ -1,10 +1,6 @@
 package tf2.entity.projectile.enemy;
 
-import java.util.List;
-
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.util.DamageSource;
 import net.minecraft.world.World;
 import tf2.entity.projectile.IEnemyProjectile;
 import tf2.entity.projectile.player.EntityMortar;
@@ -26,23 +22,5 @@ public class EntityEnemyMortar extends EntityMortar implements IEnemyProjectile
 	public EntityEnemyMortar(World worldIn, EntityLivingBase throwerIn)
 	{
 		super(worldIn, throwerIn);
-	}
-
-	@Override
-	public void setEntityDead()
-	{
-		super.setDead();
-
-		this.world.createExplosion((Entity) null, this.posX, this.posY, this.posZ, 0.0F, false);
-		List var7 = this.world.getEntitiesWithinAABB(EntityLivingBase.class, this.getEntityBoundingBox().grow(this.spread));
-		int var3;
-		for (var3 = 0; var3 < var7.size(); ++var3)
-		{
-			EntityLivingBase var8 = (EntityLivingBase) var7.get(var3);
-
-			DamageSource var201 = this.damageSource();
-			var8.attackEntityFrom(var201, (float) this.damage);
-			var8.hurtResistantTime = 0;
-		}
 	}
 }

--- a/java/tf2/entity/projectile/player/EntityFriendBullet.java
+++ b/java/tf2/entity/projectile/player/EntityFriendBullet.java
@@ -1,11 +1,6 @@
 package tf2.entity.projectile.player;
 
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.monster.EntityGolem;
-import net.minecraft.entity.monster.IMob;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import tf2.entity.projectile.IFriendProjectile;
 
@@ -25,22 +20,5 @@ public class EntityFriendBullet extends EntityBullet implements IFriendProjectil
 	public EntityFriendBullet(World worldIn, EntityLivingBase throwerIn)
 	{
 		super(worldIn, throwerIn);
-	}
-
-	@Override
-	protected void onHit(RayTraceResult raytraceResultIn)
-	{
-		Entity entity = raytraceResultIn.entityHit;
-		if (entity != null)
-		{
-			if (!(entity instanceof EntityPlayer) || !(entity instanceof EntityGolem && !(entity instanceof IMob)))
-			{
-				super.onHit(raytraceResultIn);
-			}
-		}
-		else
-		{
-			super.onHitBlock(raytraceResultIn);
-		}
 	}
 }

--- a/java/tf2/entity/projectile/player/EntityFriendGrenade.java
+++ b/java/tf2/entity/projectile/player/EntityFriendGrenade.java
@@ -4,9 +4,6 @@ import java.util.List;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.monster.EntityGolem;
-import net.minecraft.entity.monster.IMob;
-import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumParticleTypes;
@@ -71,7 +68,7 @@ public class EntityFriendGrenade extends EntityTFProjectile implements IFriendPr
  		{
  			EntityLivingBase var8 = (EntityLivingBase)var7.get(var3);
 
- 			if(var8 != this.thrower && !(var8 instanceof EntityPlayer) && !(var8 instanceof EntityGolem && !(var8 instanceof IMob)))
+ 			if(var8 != this.thrower)
  			{
  				DamageSource var201 = this.damageSource();
  	 			var8.attackEntityFrom(var201, (float)this.damage * 0.5F);

--- a/java/tf2/entity/projectile/player/EntityFriendImpact.java
+++ b/java/tf2/entity/projectile/player/EntityFriendImpact.java
@@ -1,11 +1,6 @@
 package tf2.entity.projectile.player;
 
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.monster.EntityGolem;
-import net.minecraft.entity.monster.IMob;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.math.RayTraceResult;
 import net.minecraft.world.World;
 import tf2.entity.projectile.IFriendProjectile;
 
@@ -25,18 +20,5 @@ public class EntityFriendImpact extends EntityImpact implements IFriendProjectil
 	public EntityFriendImpact(World worldIn, EntityLivingBase throwerIn)
 	{
 		super(worldIn, throwerIn);
-	}
-
-	@Override
-	protected void onHit(RayTraceResult raytraceResultIn)
-	{
-		Entity entity = raytraceResultIn.entityHit;
-		if (entity != null)
-		{
-			if (!(entity instanceof EntityPlayer) || !(entity instanceof EntityGolem && !(entity instanceof IMob)))
-			{
-				super.onHit(raytraceResultIn);
-			}
-		}
 	}
 }

--- a/java/tf2/entity/projectile/player/EntityFriendMortar.java
+++ b/java/tf2/entity/projectile/player/EntityFriendMortar.java
@@ -1,13 +1,6 @@
 package tf2.entity.projectile.player;
 
-import java.util.List;
-
-import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.monster.EntityGolem;
-import net.minecraft.entity.monster.IMob;
-import net.minecraft.entity.player.EntityPlayer;
-import net.minecraft.util.DamageSource;
 import net.minecraft.world.World;
 import tf2.entity.projectile.IFriendProjectile;
 
@@ -28,25 +21,4 @@ public class EntityFriendMortar extends EntityMortar implements IFriendProjectil
 	{
 		super(worldIn, throwerIn);
 	}
-
-    @Override
-    public void setEntityDead()
-    {
-        super.setDead();
-
-    	this.world.createExplosion((Entity) null, this.posX, this.posY,this.posZ, 0.0F, false);
- 		List var7 = this.world.getEntitiesWithinAABB(EntityLivingBase.class, this.getEntityBoundingBox().grow(this.spread));
- 		int var3;
- 		for (var3 = 0; var3 < var7.size(); ++var3)
- 		{
- 			EntityLivingBase var8 = (EntityLivingBase)var7.get(var3);
-
- 			if(var8 != this.thrower && !(var8 instanceof EntityPlayer) && !(var8 instanceof EntityGolem && !(var8 instanceof IMob)))
- 			{
- 				DamageSource var201 = this.damageSource();
- 	 			var8.attackEntityFrom(var201, (float)this.damage);
- 	 			var8.hurtResistantTime = 0;
- 			}
- 		}
-    }
 }

--- a/java/tf2/entity/projectile/player/EntityHomingMissile.java
+++ b/java/tf2/entity/projectile/player/EntityHomingMissile.java
@@ -1,0 +1,98 @@
+package tf2.entity.projectile.player;
+
+import java.util.List;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.util.DamageSource;
+import net.minecraft.world.World;
+import tf2.TFDamageSource;
+import tf2.entity.projectile.EntityTFProjectile;
+
+public class EntityHomingMissile extends EntityTFProjectile
+{
+	protected EntityLivingBase owner;
+    protected EntityLivingBase target;
+    protected double spread;
+
+	public EntityHomingMissile(World worldIn)
+	{
+		super(worldIn);
+		this.setSize(0.2F, 0.2F);
+	}
+
+	public EntityHomingMissile(World worldIn, double x, double y, double z)
+	{
+		super(worldIn, x, y, z);
+	}
+
+	public EntityHomingMissile(World worldIn, EntityLivingBase throwerIn)
+	{
+		super(worldIn, throwerIn);
+		this.owner = throwerIn;
+		this.setTickAir(200);
+	}
+
+    @Override
+	public void isGravity()
+	{}
+
+	@Override
+	public DamageSource damageSource()
+	{
+		if (this.thrower == null)
+		{
+			return TFDamageSource.causeBombDamage(this);
+		}
+		else
+		{
+			return TFDamageSource.causeBombDamage(this.thrower);
+		}
+	}
+
+    @Override
+    public void setEntityDead()
+    {
+        super.setDead();
+
+    	this.world.createExplosion((Entity) null, this.posX, this.posY,this.posZ, 0.0F, false);
+ 		List var7 = this.world.getEntitiesWithinAABB(EntityLivingBase.class, this.getEntityBoundingBox().grow(this.spread));
+ 		int var3;
+ 		for (var3 = 0; var3 < var7.size(); ++var3)
+ 		{
+ 			EntityLivingBase var8 = (EntityLivingBase)var7.get(var3);
+
+			DamageSource var201 = this.damageSource();
+ 			var8.attackEntityFrom(var201, (float)this.damage);
+ 			var8.hurtResistantTime = 0;
+
+ 		}
+    }
+
+	public void setSpread(double damageIn)
+	{
+		this.spread = damageIn;
+	}
+	public double getSpread()
+	{
+		return this.spread;
+	}
+
+	@Override
+	public void writeEntityToNBT(NBTTagCompound compound)
+	{
+		super.writeEntityToNBT(compound);
+		compound.setDouble("spread", this.spread);
+	}
+
+	/**
+	 * (abstract) Protected helper method to read subclass entity data from NBT.
+	 */
+	@Override
+	public void readEntityFromNBT(NBTTagCompound compound)
+	{
+		super.readEntityFromNBT(compound);
+		this.spread = compound.getDouble("spread");
+	}
+}

--- a/java/tf2/entity/projectile/player/EntityImpact.java
+++ b/java/tf2/entity/projectile/player/EntityImpact.java
@@ -90,50 +90,49 @@ public class EntityImpact extends EntityTFProjectile
 
 	        if (entity != null)
 	        {
-	        	if ((entity instanceof EntityMobTF || entity instanceof IMob))
-	        	{
-	        		DamageSource damagesource;
 
-	                if (this.thrower == null)
-	                {
-	                    damagesource = TFDamageSource.causeBulletDamage(this, this);
-	                }
-	                else
-	                {
-	                    damagesource = TFDamageSource.causeBulletDamage(this, this.thrower);
-	                }
+        		DamageSource damagesource;
 
-	                if (this.isBurning())
-	                {
-	                    entity.setFire(5);
-	                }
+                if (this.thrower == null)
+                {
+                    damagesource = TFDamageSource.causeBulletDamage(this, this);
+                }
+                else
+                {
+                    damagesource = TFDamageSource.causeBulletDamage(this, this.thrower);
+                }
 
-	                if (entity.attackEntityFrom(damagesource, (float)this.damage))
-	                {
-	                    if (entity instanceof EntityLivingBase)
-	                    {
-	                        EntityLivingBase entitylivingbase = (EntityLivingBase)entity;
+                if (this.isBurning())
+                {
+                    entity.setFire(5);
+                }
 
-	                        if (this.thrower instanceof EntityLivingBase)
-	                        {
-	                            EnchantmentHelper.applyThornEnchantments(entitylivingbase, this.thrower);
-	                            EnchantmentHelper.applyArthropodEnchantments((EntityLivingBase)this.thrower, entitylivingbase);
-	                        }
+                if (entity.attackEntityFrom(damagesource, (float)this.damage))
+                {
+                    if (entity instanceof EntityLivingBase)
+                    {
+                        EntityLivingBase entitylivingbase = (EntityLivingBase)entity;
 
-	                        this.bulletHit(entitylivingbase);
-	                        entitylivingbase.hurtResistantTime = 0;
+                        if (this.thrower instanceof EntityLivingBase)
+                        {
+                            EnchantmentHelper.applyThornEnchantments(entitylivingbase, this.thrower);
+                            EnchantmentHelper.applyArthropodEnchantments((EntityLivingBase)this.thrower, entitylivingbase);
+                        }
 
-	                        if (this.thrower != null && entitylivingbase != this.thrower && entitylivingbase instanceof EntityPlayer && this.thrower instanceof EntityPlayerMP)
-	                        {
-	                            ((EntityPlayerMP)this.thrower).connection.sendPacket(new SPacketChangeGameState(6, 0.0F));
-	                        }
-	                    }
-	                }
-	        	}
-	        	else if(entity instanceof IProjectile)
-	        	{
-	        		entity.setDead();
-	        	}
+                        this.bulletHit(entitylivingbase);
+                        entitylivingbase.hurtResistantTime = 0;
+
+                        if (this.thrower != null && entitylivingbase != this.thrower && entitylivingbase instanceof EntityPlayer && this.thrower instanceof EntityPlayerMP)
+                        {
+                            ((EntityPlayerMP)this.thrower).connection.sendPacket(new SPacketChangeGameState(6, 0.0F));
+                        }
+                    }
+                }
+
+				if(entity instanceof IProjectile)
+				{
+					entity.setDead();
+				}
 	        }
 	    }
 }

--- a/java/tf2/entity/projectile/player/EntityMortar.java
+++ b/java/tf2/entity/projectile/player/EntityMortar.java
@@ -4,8 +4,6 @@ import java.util.List;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
-import net.minecraft.entity.monster.EntityGolem;
-import net.minecraft.entity.monster.IMob;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.DamageSource;
 import net.minecraft.util.EnumParticleTypes;
@@ -72,7 +70,7 @@ public class EntityMortar extends EntityTFProjectile
  		{
  			EntityLivingBase var8 = (EntityLivingBase)var7.get(var3);
 
- 			if(var8 != this.thrower && !(var8 instanceof EntityGolem && !(var8 instanceof IMob)))
+ 			if(var8 != this.thrower)
  			{
  				DamageSource var201 = this.damageSource();
  	 			var8.attackEntityFrom(var201, (float)this.damage);

--- a/java/tf2/event/TFHurtEvent.java
+++ b/java/tf2/event/TFHurtEvent.java
@@ -1,6 +1,8 @@
 package tf2.event;
 
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.monster.EntityGolem;
+import net.minecraft.entity.monster.IMob;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.SoundEvents;
 import net.minecraft.item.ItemStack;
@@ -13,7 +15,11 @@ import net.minecraftforge.event.entity.living.LivingAttackEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import tf2.TFItems;
+import tf2.entity.mob.enemy.EntityMobTF;
+import tf2.entity.mob.frend.EntityFriendMecha;
 import tf2.entity.mob.frend.EntityMobCF;
+import tf2.entity.projectile.IEnemyProjectile;
+import tf2.entity.projectile.IFriendProjectile;
 import tf2.items.guns.ItemTFGunsSG;
 import tf2.items.guns.ItemTFGunsSMG;
 import tf2.potion.TFPotionPlus;
@@ -135,6 +141,17 @@ public class TFHurtEvent
 		EntityLivingBase target = event.getEntityLiving();
 		DamageSource damage = event.getSource();
 		float amount = event.getAmount();
+
+		if((damage.getTrueSource() instanceof EntityMobTF || damage.getImmediateSource() instanceof IEnemyProjectile) && target instanceof EntityMobTF)
+		{
+			event.setCanceled(true);
+		}
+		if((damage.getTrueSource() instanceof EntityFriendMecha || damage.getImmediateSource() instanceof IFriendProjectile) && (target instanceof EntityPlayer || (target instanceof EntityGolem && !(target instanceof IMob))))
+		{
+			event.setCanceled(true);
+		}
+
+
 
 		if (target != null && !target.world.isRemote && target instanceof EntityPlayer)
 		{

--- a/java/tf2/event/TFLivingUpdateEvent.java
+++ b/java/tf2/event/TFLivingUpdateEvent.java
@@ -1,12 +1,19 @@
 package tf2.event;
 
+import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.monster.EntityGolem;
+import net.minecraft.entity.monster.IMob;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.math.MathHelper;
+import net.minecraftforge.event.entity.ProjectileImpactEvent;
 import net.minecraftforge.event.entity.living.LivingEvent.LivingUpdateEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import tf2.entity.mob.enemy.EntityMobTF;
+import tf2.entity.projectile.IEnemyProjectile;
+import tf2.entity.projectile.IFriendProjectile;
 import tf2.items.guns.ItemTFGuns;
 import tf2.items.guns.ItemTFGunsHG;
 import tf2.items.guns.ItemTFGunsLMG;
@@ -68,6 +75,23 @@ public class TFLivingUpdateEvent
 					}
 				}
 			}
+		}
+	}
+
+	@SubscribeEvent
+	public void onTFProjectileImpact(ProjectileImpactEvent event)
+	{
+		Entity projectile = event.getEntity();
+		Entity target = event.getRayTraceResult().entityHit;
+
+		if(target instanceof EntityMobTF && projectile instanceof IEnemyProjectile)
+		{
+			event.setCanceled(true);
+		}
+
+		if((target instanceof EntityPlayer || (target instanceof EntityGolem && !(target instanceof IMob))) && projectile instanceof IFriendProjectile)
+		{
+			event.setCanceled(true);
 		}
 	}
 }


### PR DESCRIPTION
〇IFriendProjectileを実装した場合、EntityPlayer及びIMobを実装していないEntityGolemを継承したEntityに対して弾が当たらなくなり、ダメージも入らないように修正
〇IEnemyProjectileを実装した場合、EntityMobTFを継承したEntityに対して弾が当たらなくなり、ダメージも入らないように修正

〇EntityHomingMissile(仮)クラスの作成